### PR TITLE
Add ctx package for context helpers

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,6 +152,7 @@ Logs below the configured level will be discarded.
 ```
 chronolog/
 ├── entries/         # Log entry types
+├── ctx/             # Public context helpers
 ├── internal/        # Utility and handler logic
 ├── chronolog.go     # Main API
 └── README.md

--- a/ctx/context.go
+++ b/ctx/context.go
@@ -1,0 +1,37 @@
+package ctx
+
+import (
+	"context"
+
+	"github.com/Astronotify/chronolog/internal"
+)
+
+// WithTraceID stores the given trace ID in the context.
+func WithTraceID(ctx context.Context, traceID string) context.Context {
+	return internal.WithTraceID(ctx, traceID)
+}
+
+// WithSpanID stores the given span ID in the context.
+func WithSpanID(ctx context.Context, spanID string) context.Context {
+	return internal.WithSpanID(ctx, spanID)
+}
+
+// WithParentSpanID stores the parent span ID in the context.
+func WithParentSpanID(ctx context.Context, parentSpanID string) context.Context {
+	return internal.WithParentSpanID(ctx, parentSpanID)
+}
+
+// WithCommitHash stores the commit hash in the context.
+func WithCommitHash(ctx context.Context, commitHash string) context.Context {
+	return internal.WithCommitHash(ctx, commitHash)
+}
+
+// WithBuildTime stores the build time in the context.
+func WithBuildTime(ctx context.Context, buildTime string) context.Context {
+	return internal.WithBuildTime(ctx, buildTime)
+}
+
+// WithVersion stores the application version in the context.
+func WithVersion(ctx context.Context, version string) context.Context {
+	return internal.WithVersion(ctx, version)
+}

--- a/ctx/context_test.go
+++ b/ctx/context_test.go
@@ -1,0 +1,65 @@
+package ctx_test
+
+import (
+	"context"
+	"testing"
+
+	chronologctx "github.com/Astronotify/chronolog/ctx"
+	"github.com/Astronotify/chronolog/internal"
+)
+
+func TestContextSetters(t *testing.T) {
+	tests := []struct {
+		name      string
+		setter    func(context.Context) context.Context
+		extractor func(context.Context) string
+		want      string
+	}{
+		{
+			name:      "traceID",
+			setter:    func(c context.Context) context.Context { return chronologctx.WithTraceID(c, "trace") },
+			extractor: internal.ExtractTraceID,
+			want:      "trace",
+		},
+		{
+			name:      "spanID",
+			setter:    func(c context.Context) context.Context { return chronologctx.WithSpanID(c, "span") },
+			extractor: internal.ExtractSpanID,
+			want:      "span",
+		},
+		{
+			name:      "parentSpanID",
+			setter:    func(c context.Context) context.Context { return chronologctx.WithParentSpanID(c, "parent") },
+			extractor: internal.ExtractParentSpanID,
+			want:      "parent",
+		},
+		{
+			name:      "commitHash",
+			setter:    func(c context.Context) context.Context { return chronologctx.WithCommitHash(c, "commit") },
+			extractor: internal.ExtractCommitHash,
+			want:      "commit",
+		},
+		{
+			name:      "buildTime",
+			setter:    func(c context.Context) context.Context { return chronologctx.WithBuildTime(c, "time") },
+			extractor: internal.ExtractBuildTime,
+			want:      "time",
+		},
+		{
+			name:      "version",
+			setter:    func(c context.Context) context.Context { return chronologctx.WithVersion(c, "v1") },
+			extractor: internal.ExtractVersion,
+			want:      "v1",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := tt.setter(context.Background())
+			got := tt.extractor(ctx)
+			if got != tt.want {
+				t.Errorf("%s: expected %q, got %q", tt.name, tt.want, got)
+			}
+		})
+	}
+}

--- a/examples/main.go
+++ b/examples/main.go
@@ -6,8 +6,8 @@ import (
 	"time"
 
 	"github.com/Astronotify/chronolog"
+	chronologctx "github.com/Astronotify/chronolog/ctx"
 	"github.com/Astronotify/chronolog/entries"
-	"github.com/Astronotify/chronolog/internal"
 	Level "github.com/Astronotify/chronolog/level"
 )
 
@@ -23,14 +23,14 @@ func main() {
 	ctx := context.Background()
 
 	// Set up context with commit hash, build time and version
-	ctx = internal.WithCommitHash(ctx, "abc1234def5678ghijkl9012mnop3456")
-	ctx = internal.WithBuildTime(ctx, "2023-10-01T12:00:00Z")
-	ctx = internal.WithVersion(ctx, "0.1.0")
+	ctx = chronologctx.WithCommitHash(ctx, "abc1234def5678ghijkl9012mnop3456")
+	ctx = chronologctx.WithBuildTime(ctx, "2023-10-01T12:00:00Z")
+	ctx = chronologctx.WithVersion(ctx, "0.1.0")
 
 	// Set up context with trace and span IDs
-	ctx = internal.WithTraceID(ctx, "trace-12345")
-	ctx = internal.WithSpanID(ctx, "span-67890")
-	ctx = internal.WithParentSpanID(ctx, "parent-span-54321")
+	ctx = chronologctx.WithTraceID(ctx, "trace-12345")
+	ctx = chronologctx.WithSpanID(ctx, "span-67890")
+	ctx = chronologctx.WithParentSpanID(ctx, "parent-span-54321")
 
 	// Simple trace log
 	chronolog.Trace(ctx, "Starting profile creation process")


### PR DESCRIPTION
## Summary
- add a public `ctx` package exposing context helper functions
- update README project structure
- update example to use the new ctx package
- test context helpers

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_684032af2ed88322afebf9bb4cada145