### PR TITLE
Map custom levels to slog levels

### DIFF
--- a/chronolog.go
+++ b/chronolog.go
@@ -181,7 +181,22 @@ func write(ctx context.Context, entry any) {
 	if !shouldLog(level) {
 		return
 	}
-	logger.Log(ctx, slog.LevelInfo, "log", slog.Any("event", entry))
+	logger.Log(ctx, mapLogLevel(level), "log", slog.Any("event", entry))
+}
+
+func mapLogLevel(level Level.LogLevel) slog.Level {
+	switch level {
+	case Level.Trace, Level.Debug:
+		return slog.LevelDebug
+	case Level.Info:
+		return slog.LevelInfo
+	case Level.Warn:
+		return slog.LevelWarn
+	case Level.Error:
+		return slog.LevelError
+	default:
+		return slog.LevelInfo
+	}
 }
 
 func (c *Config) applyDefaults() {

--- a/chronolog_test.go
+++ b/chronolog_test.go
@@ -1,0 +1,48 @@
+package chronolog
+
+import (
+	"context"
+	"errors"
+	"log/slog"
+	"reflect"
+	"testing"
+
+	Level "github.com/Astronotify/chronolog/level"
+)
+
+type capturingHandler struct {
+	levels []slog.Level
+}
+
+func (h *capturingHandler) Enabled(_ context.Context, _ slog.Level) bool { return true }
+func (h *capturingHandler) Handle(_ context.Context, r slog.Record) error {
+	h.levels = append(h.levels, r.Level)
+	return nil
+}
+func (h *capturingHandler) WithAttrs(_ []slog.Attr) slog.Handler { return h }
+func (h *capturingHandler) WithGroup(string) slog.Handler        { return h }
+
+func TestWriteLevelMapping(t *testing.T) {
+	handler := &capturingHandler{}
+	logger = slog.New(handler)
+	minimumLogLevel = Level.Trace
+
+	ctx := context.Background()
+	Trace(ctx, "trace")
+	Debug(ctx, "debug")
+	Info(ctx, "info")
+	Warn(ctx, "warn")
+	Error(ctx, errors.New("err"))
+
+	want := []slog.Level{
+		slog.LevelDebug,
+		slog.LevelDebug,
+		slog.LevelInfo,
+		slog.LevelWarn,
+		slog.LevelError,
+	}
+
+	if !reflect.DeepEqual(handler.levels, want) {
+		t.Errorf("levels mismatch: got %v want %v", handler.levels, want)
+	}
+}


### PR DESCRIPTION
## Summary
- convert custom log levels to slog levels before logging
- add tests to verify slog level mapping

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68403481eb6c8322ac7795a8b0f2ff0f