### PR TITLE
Ensure safe logging without setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,10 @@ func main() {
 }
 ```
 
+Call `chronolog.Setup` during your application's initialization phase before
+invoking any logging functions. If it isn't called, Chronolog will fall back to
+a basic text logger.
+
 ---
 
 ## 🧱 Log Entry Types

--- a/chronolog.go
+++ b/chronolog.go
@@ -181,6 +181,9 @@ func write(ctx context.Context, entry any) {
 	if !shouldLog(level) {
 		return
 	}
+	if logger == nil {
+		logger = slog.New(slog.NewTextHandler(os.Stdout, nil))
+	}
 	logger.Log(ctx, mapLogLevel(level), "log", slog.Any("event", entry))
 }
 

--- a/chronolog_test.go
+++ b/chronolog_test.go
@@ -46,3 +46,21 @@ func TestWriteLevelMapping(t *testing.T) {
 		t.Errorf("levels mismatch: got %v want %v", handler.levels, want)
 	}
 }
+
+func TestLoggingWithoutSetupDoesNotPanic(t *testing.T) {
+	logger = nil
+	minimumLogLevel = Level.Info
+	ctx := context.Background()
+
+	defer func() {
+		if r := recover(); r != nil {
+			t.Fatalf("logging panicked: %v", r)
+		}
+	}()
+
+	Info(ctx, "hello")
+
+	if logger == nil {
+		t.Errorf("logger should be initialized by write")
+	}
+}


### PR DESCRIPTION
## Summary
- initialize a basic slog text logger when the global logger is nil
- document calling `Setup` during application startup
- test that logging without prior setup does not panic

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_684035a7a91083229a42faa391b8bae7