### PR TITLE
Fix typo in README setup sample

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ import (
 func main() {
   chronolog.Setup(chronolog.Config{
     Format: chronolog.FormatPretty,
-    MiminumLogLevel:  chronolog.Info,
+    MinimumLogLevel:  chronolog.Info,
   })
 
   ctx := context.Background()


### PR DESCRIPTION
## Summary
- fix incorrect `MiminumLogLevel` field name in the basic setup example

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_68403c823f308322b21608a1c46502f4