### PR TITLE
Add HTTP, message consumer, and lambda examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,6 +181,21 @@ chronolog/
 
 ---
 
+## 📚 Examples
+
+Several runnable examples live in the `examples/` directory:
+
+- `main.go` – comprehensive demo covering traces, operations, messages and more.
+- `httpserver/` – basic HTTP handler emitting `OperationRequestLogEntry` and
+  `OperationResponseLogEntry` for each request.
+- `message_consumer/` – illustrates a message lifecycle with `Received`,
+  `Acknowledged` and `Rejected` events.
+- `lambda/` – shows how to pair `LambdaBeginLogEntry` and `LambdaEndLogEntry`.
+
+Run any example with `go run ./examples/<name>`.
+
+---
+
 ## 📖 License
 
 MIT License

--- a/examples/httpserver/main.go
+++ b/examples/httpserver/main.go
@@ -1,0 +1,36 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"time"
+
+	"github.com/Astronotify/chronolog"
+	"github.com/Astronotify/chronolog/entries"
+)
+
+func main() {
+	chronolog.Setup(chronolog.Config{Format: chronolog.FormatPretty})
+
+	http.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+		ctx := r.Context()
+		reqID := r.Header.Get("X-Request-ID")
+		if reqID == "" {
+			reqID = fmt.Sprintf("%d", time.Now().UnixNano())
+		}
+
+		opReq := entries.NewOperationRequestLogEntry(ctx,
+			"http_request", "httpserver", reqID, r.URL.Path, r.Method)
+		chronolog.Entry(ctx, opReq)
+
+		w.WriteHeader(http.StatusOK)
+		fmt.Fprintln(w, "hello")
+
+		opRes := entries.NewOperationResponseLogEntry(opReq, http.StatusOK)
+		chronolog.Entry(ctx, opRes)
+	})
+
+	chronolog.Info(context.Background(), "listening on :8080")
+	http.ListenAndServe(":8080", nil)
+}

--- a/examples/lambda/main.go
+++ b/examples/lambda/main.go
@@ -1,0 +1,23 @@
+package main
+
+import (
+	"context"
+	"time"
+
+	"github.com/Astronotify/chronolog"
+	"github.com/Astronotify/chronolog/entries"
+)
+
+func main() {
+	chronolog.Setup(chronolog.Config{Format: chronolog.FormatPretty})
+	ctx := context.Background()
+
+	begin := entries.NewLambdaBeginLogEntry(ctx,
+		"HelloLambda", "req-123")
+	chronolog.Entry(ctx, begin)
+
+	time.Sleep(20 * time.Millisecond)
+
+	end := entries.NewLambdaEndLogEntryFromBegin(begin)
+	chronolog.Entry(ctx, end)
+}

--- a/examples/message_consumer/main.go
+++ b/examples/message_consumer/main.go
@@ -1,0 +1,31 @@
+package main
+
+import (
+	"context"
+	"time"
+
+	"github.com/Astronotify/chronolog"
+	"github.com/Astronotify/chronolog/entries"
+)
+
+func main() {
+	chronolog.Setup(chronolog.Config{Format: chronolog.FormatPretty})
+	ctx := context.Background()
+
+	received := entries.NewMessageReceivedLogEntry(ctx,
+		"msg-1", "user.signup", "email-service")
+	chronolog.Entry(ctx, received)
+
+	time.Sleep(10 * time.Millisecond)
+	ack := entries.NewMessageAcknowledgedLogEntryFromReceived(received)
+	chronolog.Entry(ctx, ack)
+
+	received2 := entries.NewMessageReceivedLogEntry(ctx,
+		"msg-2", "user.delete", "email-service")
+	chronolog.Entry(ctx, received2)
+
+	time.Sleep(5 * time.Millisecond)
+	rej := entries.NewMessageRejectedLogEntryFromReceived(received2,
+		"invalid data")
+	chronolog.Entry(ctx, rej)
+}


### PR DESCRIPTION
## Summary
- add small runnable examples for http server, message consumer and lambda usage
- mention new examples in README

## Testing
- `go test ./... -v`

------
https://chatgpt.com/codex/tasks/task_e_68403d1073008322bd1a82164eb76fa5