### PR TITLE
Add flexible run-example target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -33,9 +33,18 @@ build: ## Build the Go project
 	@echo "${YELLOW}Building the module...${RESET}"
 	go build -ldflags "$(LDFLAGS)" -o bin/$(APP_NAME) ./examples
 
+RUN_EXAMPLE_NAME := $(word 2,$(MAKECMDGOALS))
+
 run-example: ## Run the example application
-	@echo "${YELLOW}Running example...${RESET}"
-	go run ./examples/main.go
+        @echo "${YELLOW}Running example...${RESET}"
+        @if [ -z "$(RUN_EXAMPLE_NAME)" ]; then \
+                go run ./examples/main.go; \
+        else \
+                go run ./examples/$(RUN_EXAMPLE_NAME)/main.go; \
+        fi
+
+$(RUN_EXAMPLE_NAME):
+        @:
 
 ## ---------------------------------------------------------------------
 ## 🧪 Test & Quality


### PR DESCRIPTION
## Summary
- allow `make run-example` to run specific examples with optional argument

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68403f513a888322a4896b1b6602ccfa